### PR TITLE
Merge dev branch into main

### DIFF
--- a/client/directories.go
+++ b/client/directories.go
@@ -1,5 +1,23 @@
 package client
 
+/*
+   team - Embedded teamserver for Go programs and CLI applications
+   Copyright (C) 2023 Reeflective
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 import (
 	"os"
 	"os/user"
@@ -7,10 +25,11 @@ import (
 )
 
 const (
-	// configsDirName - Directory name containing config files
+	// configsDirName - Directory name containing config files.
 	teamserverClientDir = "teamclient"
 	configsDirName      = "configs"
 	logFileExt          = "teamclient"
+	dirWriteModePerm    = 0o700
 )
 
 // AppDir returns the teamclient directory of the app (named ~/.<app>/teamserver/client/),
@@ -18,12 +37,14 @@ const (
 func (tc *Client) AppDir() string {
 	user, _ := user.Current()
 	dir := filepath.Join(user.HomeDir, "."+tc.name, teamserverClientDir)
+
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		err = os.MkdirAll(dir, 0o700)
+		err = os.MkdirAll(dir, dirWriteModePerm)
 		if err != nil {
-			tc.log().Errorf("cannot write to %s root dir: %w", dir, err)
+			tc.log().Errorf("cannot write to %s root dir: %s", dir, err)
 		}
 	}
+
 	return dir
 }
 
@@ -32,11 +53,12 @@ func (tc *Client) AppDir() string {
 func (tc *Client) LogsDir() string {
 	logsDir := filepath.Join(tc.AppDir(), "logs")
 	if _, err := os.Stat(logsDir); os.IsNotExist(err) {
-		err = os.MkdirAll(logsDir, 0o700)
+		err = os.MkdirAll(logsDir, dirWriteModePerm)
 		if err != nil {
-			tc.log().Errorf("cannot write to %s root dir: %w", logsDir, err)
+			tc.log().Errorf("cannot write to %s root dir: %s", logsDir, err)
 		}
 	}
+
 	return logsDir
 }
 
@@ -44,11 +66,13 @@ func (tc *Client) LogsDir() string {
 func (tc *Client) ConfigsDir() string {
 	rootDir, _ := filepath.Abs(tc.AppDir())
 	dir := filepath.Join(rootDir, configsDirName)
+
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		err = os.MkdirAll(dir, 0o700)
+		err = os.MkdirAll(dir, dirWriteModePerm)
 		if err != nil {
-			tc.log().Errorf("cannot write to %s configs dir: %w", dir, err)
+			tc.log().Errorf("cannot write to %s configs dir: %s", dir, err)
 		}
 	}
+
 	return dir
 }

--- a/client/errors.go
+++ b/client/errors.go
@@ -1,5 +1,23 @@
 package client
 
+/*
+   team - Embedded teamserver for Go programs and CLI applications
+   Copyright (C) 2023 Reeflective
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 import "errors"
 
 var (
@@ -10,6 +28,9 @@ var (
 
 	// ErrConfig is an error related to the teamclient connection configuration.
 	ErrConfig = errors.New("client config error")
+
+	// ErrNoConfig indicates that no configuration, default or on file system, was found.
+	ErrNoConfig = errors.New("no client configuration was selected or parsed")
 
 	// ErrConfigNoUser says that the configuration has no user,
 	// which is not possible even if the client is an in-memory one.

--- a/client/options.go
+++ b/client/options.go
@@ -1,5 +1,23 @@
 package client
 
+/*
+   team - Embedded teamserver for Go programs and CLI applications
+   Copyright (C) 2023 Reeflective
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 import (
 	"fmt"
 	"io"
@@ -77,14 +95,14 @@ func WithNoLogs(noLogs bool) Options {
 }
 
 // WithLogFile sets the path to the file where teamclient logging should be done.
-// If not specified, the client log file is ~/.app/teamclient/logs/app.teamclient.log
+// If not specified, the client log file is ~/.app/teamclient/logs/app.teamclient.log.
 func WithLogFile(filePath string) Options {
 	return func(opts *opts) {
 		opts.logFile = filePath
 	}
 }
 
-// WithLogger sets the teamclient to use a specific logger for logging
+// WithLogger sets the teamclient to use a specific logger for logging.
 func WithLogger(logger *logrus.Logger) Options {
 	return func(opts *opts) {
 		opts.logger = logger


### PR DESCRIPTION
- Refactor most of the code into an internal directory
- Adapt server code with internal one
- Refactor client code with internal one.
- Refactor examples and adapt commands
- Refactor cobra command entrypoints and self-server
- Refactor examples
- Refactor examples
- Refactors
- Change the directories used by the teamserver apps
- Further tidy and fixes
- Refactor and cleanup log code
- Cleanup log code
- Fix logs
- Try to fix a weird connection issue
- Fix TLS keylogger
- Refactor logs, renamings, etc.
- Go mod tidy of commits to follow: - Rewrite the library with pluggable transports, clients &| server - Try to cleanup the code a bit, and fix things.
- Server refactoring with grpc backend out of there.
- Add server/transports/ directory with pluggable transports.
- Refactor log package and use file perm checks before starting servers/client/ Add a core package, which contains root-root version/users calls, and might also contain listener jobs management....
- Adapt command code with changes
- Same refactorings/cleanups client-side
- Add client/server options
- Fix logs in server
- Remove redundant config loadings
- Fixes in server
- Remove all calls to panic and replace with errors + multiple cleanups and fixes
- Database logger back
- Cleanup log calls
- Change errors formatting directives
- Cleanups
- Fix to server init to early
- Fix in-memory grpc
- Refactor code
- Cleanup commands
- Big refactoring and refining of APIs:
- First refactoring and harmonization of errors everywhere
- Change config file names/extensions.
- Move all grpc code from core
- Use commands stdout when possible
- Further cleanup/changes to log and fixes to certs
- Enhance/fix command tree
- Harmonize client logging code
- Harmonize server log code + fixes to client log
- Ensure client/server options are applied correctly
- Add job management, refactor serve start functions
- Add job control, harmonize listener serving API/internals
- Start adding job control to commands, display status + enhancements
- Harmonize logging for client: - Synchronize with io when used in commands. - Log all errors before being returned by public API. - Cleanup
- Fixes to client logging
- Harmonize server logging and sync with command io
- Refactor internal log stdio
- Split stdout/stderr logging
- Add golangci.yml file + update go.mod
- Update README
- Add github workflows
- Update go build actions
- Lint client code
