### PR TITLE
dev

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -34,6 +34,7 @@ import (
 //
 // This client object is by default not connected to any teamserver,
 // and has therefore no way of fulfilling its core duties, on purpose.
+// The client also DOES NOT include any teamserver-side code.
 //
 // This teamclient core job is to:
 // - Fetch, configure and use teamserver endpoint configurations.
@@ -42,8 +43,11 @@ import (
 //
 // Additionally, this client offers:
 // - Pre-configured loggers for all client-side related events.
-// - A builtin, app-specific filesystem (in memory or on disk).
 // - Various options to configure its backends and behaviors.
+// - A builtin, abstracted and app-specific filesystem (in memory or on disk).
+//
+// Various combinations of teamclient/teamserver usage are possible.
+// Please see the Go module example/ directory for a list of them.
 type Client struct {
 	name         string         // Name of the teamclient/teamserver application.
 	opts         *opts          // All configurable things for the teamclient.
@@ -66,7 +70,7 @@ type Client struct {
 // remote) to setup, initiate and use a connection to this remote teamserver.
 //
 // The type parameter `clientConn` of this interface is a purely syntactic sugar
-// to indicate that any dialer should return a user-defined but specific object
+// to indicate that any dialer should/may return a user-defined but specific object
 // from its Dial() method. Library users can register hooks to the teamclient.Client
 // using this dialer, and this clientConn will be provided to these hooks.
 //
@@ -84,6 +88,7 @@ type Dialer[clientConn any] interface {
 	// Dial should connect to the endpoint available in the client configuration.
 	// Note that the configuration is not required as a function parameter, since
 	// the dialer has already been provided access to the entire teamclient in Init()
+	// The `clientConn` type is then passed to the teamclient WithPostConnectHooks().
 	Dial() (conn clientConn, err error)
 
 	// Close should close the connection or any related component.

--- a/client/directories.go
+++ b/client/directories.go
@@ -25,14 +25,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/reeflective/team/internal/assets"
 	"github.com/reeflective/team/internal/log"
-)
-
-const (
-	// configsDirName - Directory name containing config files.
-	teamserverClientDir = "teamclient"
-	logsDirName         = "logs"
-	configsDirName      = "configs"
 )
 
 // HomeDir returns the root application directory (~/.app/ by default).
@@ -67,7 +61,7 @@ func (tc *Client) HomeDir() string {
 // creating the directory if needed, or logging an error event if failing to create it.
 // This directory is used to store teamclient logs and remote server configs.
 func (tc *Client) TeamDir() string {
-	dir := filepath.Join(tc.HomeDir(), teamserverClientDir)
+	dir := filepath.Join(tc.HomeDir(), assets.DirClient)
 
 	err := tc.fs.MkdirAll(dir, log.DirPerm)
 	if err != nil {
@@ -80,7 +74,7 @@ func (tc *Client) TeamDir() string {
 // LogsDir returns the directory of the teamclient logs (~/.app/logs), creating
 // the directory if needed, or logging a fatal event if failing to create it.
 func (tc *Client) LogsDir() string {
-	logsDir := filepath.Join(tc.TeamDir(), logsDirName)
+	logsDir := filepath.Join(tc.TeamDir(), assets.DirLogs)
 
 	err := tc.fs.MkdirAll(logsDir, log.DirPerm)
 	if err != nil {
@@ -95,7 +89,7 @@ func (tc *Client) LogsDir() string {
 // if needed, or logging a fatal event if failing to create it.
 func (tc *Client) ConfigsDir() string {
 	rootDir, _ := filepath.Abs(tc.TeamDir())
-	dir := filepath.Join(rootDir, configsDirName)
+	dir := filepath.Join(rootDir, assets.DirConfigs)
 
 	err := tc.fs.MkdirAll(dir, log.DirPerm)
 	if err != nil {

--- a/client/log.go
+++ b/client/log.go
@@ -37,9 +37,9 @@ func (tc *Client) NamedLogger(pkg, stream string) *logrus.Entry {
 	})
 }
 
-// WithLoggerStdout sets the to which the stdout logger (not the file logger)
-// should write to. This option is used by the teamclient cobra command tree
-// to coordinate its basic I/O/err with the teamclient backend.
+// SetLogWriter sets the stream to which the stdio logger (not the file logger)
+// should write to. This option is used by the teamclient cobra command tree to
+// synchronize its basic I/O/err with the teamclient backend.
 func (tc *Client) SetLogWriter(stdout, stderr io.Writer) {
 	tc.stdoutLogger.Out = stdout
 	// TODO: Pass stderr to log internals.

--- a/internal/assets/fs.go
+++ b/internal/assets/fs.go
@@ -36,6 +36,19 @@ const (
 	FileWriteOpenMode = os.O_APPEND | os.O_CREATE | os.O_WRONLY
 )
 
+const (
+	// Teamclient.
+
+	DirClient  = "teamclient" // DirClient is the name of the teamclient subdirectory.
+	DirLogs    = "logs"       // DirLogs subdirectory name
+	DirConfigs = "configs"    // DirConfigs subdirectory name
+
+	// Teamserver.
+
+	DirServer = "teamserver" // DirClient is the name of the teamserver subdirectory.
+	DirCerts  = "certs"      // DirCerts subdirectory name
+)
+
 // FS is a filesystem abstraction for teamservers and teamclients.
 // When either of them are configured to run in memory only, this
 // filesystem is initialized accordingly, otherwise it will forward

--- a/server/commands/commands.go
+++ b/server/commands/commands.go
@@ -1,5 +1,23 @@
 package commands
 
+/*
+   team - Embedded teamserver for Go programs and CLI applications
+   Copyright (C) 2023 Reeflective
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 import (
 	"github.com/reeflective/team/client"
 	cli "github.com/reeflective/team/client/commands"

--- a/server/commands/completers.go
+++ b/server/commands/completers.go
@@ -1,5 +1,23 @@
 package commands
 
+/*
+   team - Embedded teamserver for Go programs and CLI applications
+   Copyright (C) 2023 Reeflective
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 import (
 	"fmt"
 	"net"

--- a/server/commands/user.go
+++ b/server/commands/user.go
@@ -70,9 +70,15 @@ func createUserCmd(serv *server.Server, cli *client.Client) func(cmd *cobra.Comm
 
 		fmt.Fprintf(cmd.OutOrStdout(), command.Info+"Generating new client certificate, please wait ... \n")
 
-		configJSON, err := serv.NewUserConfig(name, lhost, lport)
+		config, err := serv.NewUser(name, lhost, lport)
 		if err != nil {
 			fmt.Fprintf(cmd.ErrOrStderr(), command.Warn+"%s\n", err)
+			return
+		}
+
+		configJSON, err := json.Marshal(config)
+		if err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), command.Warn+"JSON marshaling error: %s\n", err)
 			return
 		}
 

--- a/server/config.go
+++ b/server/config.go
@@ -1,5 +1,23 @@
 package server
 
+/*
+   team - Embedded teamserver for Go programs and CLI applications
+   Copyright (C) 2023 Reeflective
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 import (
 	"encoding/hex"
 	"encoding/json"

--- a/server/config.go
+++ b/server/config.go
@@ -20,12 +20,25 @@ const (
 	blankPort = uint16(0)
 )
 
+// Config represents the configuration of a given application teamserver.
+// It contains anonymous embedded structs as subsections, for logging,
+// daemon mode bind addresses, and persistent teamserver listeners
+//
+// Its default path is ~/.app/teamserver/configs/app.teamserver.cfg.
+// It uses the following default values:
+// - Daemon host: ""
+// - Daemon port: 31416
+// - logging file level: Info.
 type Config struct {
+	// When the teamserver command `app teamserver daemon` is executed
+	// without --host/--port flags, the teamserver will use the config.
 	DaemonMode struct {
 		Host string `json:"host"`
 		Port int    `json:"port"`
 	} `json:"daemon_mode"`
 
+	// Logging controls the file-based logging level, whether or not
+	// to log TLS keys to file, and whether to log specific gRPC payloads.
 	Log struct {
 		Level              int  `json:"level"`
 		GRPCUnaryPayloads  bool `json:"grpc_unary_payloads"`
@@ -33,6 +46,8 @@ type Config struct {
 		TLSKeyLogger       bool `json:"tls_key_logger"`
 	} `json:"log"`
 
+	// Listeners is a list of persistent teamserver listeners.
+	// They are started when the teamserver daemon command/mode is.
 	Listeners []struct {
 		Name string `json:"name"`
 		Host string `json:"host"`
@@ -41,7 +56,7 @@ type Config struct {
 	} `json:"listeners"`
 }
 
-// GetServerConfigPath - File path to the server config.json file.
+// ConfigPath returns the path to the server config.json file, on disk or in-memory.
 func (ts *Server) ConfigPath() string {
 	appDir := ts.TeamDir()
 	configDir := filepath.Join(appDir, "configs")
@@ -56,7 +71,8 @@ func (ts *Server) ConfigPath() string {
 	return serverConfigPath
 }
 
-// GetConfig returns the team server configuration struct.
+// GetConfig returns the team server configuration as a struct.
+// If no server configuration file is found on disk, the default one is used.
 func (ts *Server) GetConfig() *Config {
 	cfgLog := ts.NamedLogger("config", "server")
 
@@ -100,7 +116,8 @@ func (ts *Server) GetConfig() *Config {
 	return ts.opts.config
 }
 
-// Save - Save config file to disk.
+// Save saves config file to disk.
+// This uses the on-disk filesystem even if the teamclient is in memory mode.
 func (ts *Server) SaveConfig(cfg *Config) error {
 	cfgLog := ts.NamedLogger("config", "server")
 

--- a/server/core.go
+++ b/server/core.go
@@ -36,46 +36,80 @@ import (
 	"gorm.io/gorm"
 )
 
-// Server is a team server.
+// Server is the core driver of an application teamserver.
+// It is the counterpart to and plays a similar role than that
+// of the team/client.Client type, ie. that it provides tools
+// to any application/program to become a teamserver of itself.
+//
+// The server object can run on its own, without any teamclient attached
+// or connected: it fulfills the reeflective/team.Client interface, and
+// any teamserver can also be a client of itself, without configuration.
+//
+// The core job of the Server is to, non-exhaustively:
+//   - Store and manage a list of users with a zero-trust identity system
+//     (ie. public-key based), with ways to import/export these lists.
+//   - Register, start and control teamserver listener/server stacks, for
+//     many application clients to connect and consume the teamserver app.
+//   - Offer version and user information to all teamclients.
+//
+// Additionally and similarly to the team/client.Client, it gives:
+//   - Pre-configured loggers that listener stacks and server consumers
+//     can use at any step of their application.
+//   - Various options to configure its backends and behaviors.
+//   - A builtin, app-specific abstracted filesystem (in-memory or on-disk).
+//   - Additionally, an API to further register and control listeners.
+//
+// Various combinations of teamclient/teamserver usage are possible.
+// Please see the Go module example/ directory for a list of them.
 type Server struct {
 	// Core
-	name         string
-	rootDirEnv   string
-	fileLogger   *logrus.Logger
-	stdoutLogger *logrus.Logger
-	userTokens   *sync.Map
-	initOnce     *sync.Once
-	opts         *opts[any]
-	db           *gorm.DB
-	dbInitOnce   sync.Once
-	certs        *certs.Manager
-	fs           *assets.FS
+	name       string     // Name of the application using the teamserver.
+	rootDirEnv string     // APP_ROOT_DIR env variable value if any
+	opts       *opts[any] // Server options
+	fs         *assets.FS // Server filesystem, on-disk or embedded
+
+	// Logging
+	fileLogger   *logrus.Logger // Can be in-memory if the teamserver is configured.
+	stdoutLogger *logrus.Logger // Logging level independent from the file logger.
+
+	// Users
+	userTokens *sync.Map      // Refreshed entirely when a user is kicked.
+	certs      *certs.Manager // Manages all the certificate infrastructure.
+	db         *gorm.DB       // Stores certificates and users data.
+	dbInitOnce sync.Once      // A single database can be used in a teamserver lifetime.
 
 	// Listeners and job control
-	self     Handler[any]
-	handlers map[string]Handler[any]
-	jobs     *jobs
+	initOnce *sync.Once               // Some options can only have an effect at first start.
+	self     Listener[any]            // The default listener stack used by the teamserver.
+	handlers map[string]Listener[any] // Other listeners available by name.
+	jobs     *jobs                    // Listeners job control
 }
 
 // New creates a new teamserver for the provided application name.
-// This server can handle any number of remote clients for a given application
-// named "teamserver", including its own local runtime (fully in-memory) client.
-//
-// All errors returned from this call are critical, in that the server could not
-// run properly in its most basic state. If an error is raised, no server is returned.
+// Only one such teamserver should be created an application of any given name.
+// Since by default, any teamserver can have any number of runtime clients, you
+// are not required to provide any specific server.Listener type to serve clients.
 //
 // This call to create the server only creates the application default directory.
 // No files, logs, connections or any interaction with the os/filesystem are made.
+//
+// Errors:
+//   - All errors returned from this call are critical, in that the server could not
+//     run properly in its most basic state, which may happen if the teamclient cannot
+//     use and write to its on-disk directories/backends and log files.
+//     No server is returned if the error is not nil.
+//   - All methods of the teamserver core which return an error will always log this
+//     error to the various teamserver log files/output streams, so that all actions
+//     of teamserver can be recorded and watched out in various places.
 func New(application string, options ...Options) (*Server, error) {
 	server := &Server{
 		name:       application,
 		rootDirEnv: fmt.Sprintf("%s_ROOT_DIR", strings.ToUpper(application)),
 		opts:       newDefaultOpts(),
-
 		userTokens: &sync.Map{},
 		initOnce:   &sync.Once{},
 		jobs:       newJobs(),
-		handlers:   make(map[string]Handler[any]),
+		handlers:   make(map[string]Listener[any]),
 	}
 
 	server.apply(options...)
@@ -113,7 +147,22 @@ func (ts *Server) Name() string {
 	return ts.name
 }
 
-// Version returns the server binary version information.
+// Self returns a new application team/client.Client (with the same app name),
+// using any provided options for client behavior.
+//
+// This teamclient implements by default the root team/Teamclient interface
+// (directly through the server), but passing user-specific dialer stack options
+// to this function and by providing the corresponding server options for your
+// pair, you can use in-memory clients which will use the complete RPC stack
+// of the application using this teamserver.
+// See the server.Listener and client.Dialer types documentation for more.
+func (ts *Server) Self(opts ...client.Options) *client.Client {
+	teamclient, _ := client.New(ts.Name(), ts, opts...)
+
+	return teamclient
+}
+
+// Version returns the teamserver binary version information.
 func (ts *Server) Version() (team.Version, error) {
 	dirty := version.GitDirty != ""
 	semVer := version.Semantic()
@@ -140,6 +189,7 @@ func (ts *Server) Version() (team.Version, error) {
 }
 
 // Users returns the list of users in the teamserver database, and their information.
+// Any error raised during querying the database is returned, along with all users.
 func (ts *Server) Users() ([]team.User, error) {
 	if err := ts.initDatabase(); err != nil {
 		return nil, ts.errorf("%w: %w", ErrDatabase, err)
@@ -168,12 +218,23 @@ func (ts *Server) Users() ([]team.User, error) {
 	return users, nil
 }
 
+// Filesystem returns an abstract filesystem used by the teamserver.
+// This filesystem can be either of two things:
+//   - By default, the on-disk filesystem, without any specific bounds.
+//   - If the teamserver was created with the InMemory() option, a full
+//     in-memory filesystem (with root `.app/`).
+//
+// Use cases for this filesystem might include:
+//   - The wish to have a fully abstracted filesystem to work for testing
+//   - Ensuring that the filesystem code in your application remains the
+//     same regardless of the underlying, actual filesystem.
+//
+// The type returned is currently an internal type because it wraps some
+// os.Filesystem methods for working more transparently: this may change
+// in the future if the Go stdlib offers write support to its new io/fs.FS.
+//
+// SERVER note: Runtime clients can run with the client.InMemory() option,
+// without any impact on the teamserver filesystem and its behavior.
 func (ts *Server) Filesystem() *assets.FS {
 	return ts.fs
-}
-
-func (ts *Server) Self(opts ...client.Options) *client.Client {
-	teamclient, _ := client.New(ts.Name(), ts, opts...)
-
-	return teamclient
 }

--- a/server/db.go
+++ b/server/db.go
@@ -1,5 +1,23 @@
 package server
 
+/*
+   team - Embedded teamserver for Go programs and CLI applications
+   Copyright (C) 2023 Reeflective
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 import (
 	"encoding/json"
 	"fmt"

--- a/server/db.go
+++ b/server/db.go
@@ -18,6 +18,9 @@ const (
 	maxOpenConns = 100
 )
 
+// DatabaseConfig returns the server database backend configuration struct.
+// If configuration could be found on disk, the default Sqlite file-based
+// database is returned, with app-corresponding file paths.
 func (ts *Server) DatabaseConfig() *db.Config {
 	cfg, err := ts.getDatabaseConfig()
 	if err != nil {

--- a/server/directories.go
+++ b/server/directories.go
@@ -26,15 +26,14 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/reeflective/team/internal/assets"
 	"github.com/reeflective/team/internal/log"
 )
 
-const (
-	teamserverDir = "teamserver"
-	logsDir       = "logs"
-	certsDir      = "certs"
-)
-
+// HomeDir returns the root application directory (~/.app/ by default).
+// This directory can be set with the environment variable <APP>_ROOT_DIR.
+// This directory is not to be confused with the ~/.app/teamserver directory
+// returned by the server.TeamDir(), which is specific to the app teamserver.
 func (ts *Server) HomeDir() string {
 	value := os.Getenv(fmt.Sprintf("%s_ROOT_DIR", strings.ToUpper(ts.name)))
 
@@ -59,10 +58,11 @@ func (ts *Server) HomeDir() string {
 	return dir
 }
 
-// TeamDir returns the directory of the team server app (named ~/.<app>/teamserver/),
-// creating the directory if needed, or logging a fatal event if failing to create it.
+// TeamDir returns the teamserver directory of the app (named ~/.<app>/teamserver/),
+// creating the directory if needed, or logging an error event if failing to create it.
+// This directory is used to store teamserver certificates, database, logs, and configs.
 func (ts *Server) TeamDir() string {
-	dir := path.Join(ts.HomeDir(), teamserverDir)
+	dir := path.Join(ts.HomeDir(), assets.DirServer)
 
 	err := ts.fs.MkdirAll(dir, log.DirPerm)
 	if err != nil {
@@ -75,7 +75,7 @@ func (ts *Server) TeamDir() string {
 // LogsDir returns the directory of the client (~/.app-server/logs), creating
 // the directory if needed, or logging a fatal event if failing to create it.
 func (ts *Server) LogsDir() string {
-	logDir := path.Join(ts.TeamDir(), logsDir)
+	logDir := path.Join(ts.TeamDir(), assets.DirLogs)
 
 	err := ts.fs.MkdirAll(logDir, log.DirPerm)
 	if err != nil {
@@ -85,8 +85,10 @@ func (ts *Server) LogsDir() string {
 	return logDir
 }
 
+// CertificatesDir returns the directory storing users CA PEM files as backup,
+// (~/.app/teamserver/certs), either on-disk or in-memory if the teamserver is.
 func (ts *Server) CertificatesDir() string {
-	certDir := path.Join(ts.TeamDir(), certsDir)
+	certDir := path.Join(ts.TeamDir(), assets.DirCerts)
 
 	err := ts.fs.MkdirAll(certDir, log.DirPerm)
 	if err != nil {

--- a/server/errors.go
+++ b/server/errors.go
@@ -1,5 +1,23 @@
 package server
 
+/*
+   team - Embedded teamserver for Go programs and CLI applications
+   Copyright (C) 2023 Reeflective
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 import "errors"
 
 var (

--- a/server/errors.go
+++ b/server/errors.go
@@ -35,7 +35,7 @@ var (
 	// ErrDatabase is an error raised by the database backend.
 	ErrDatabase = errors.New("database")
 
-	// ErrTeamServer is an error raised by the teamserver code.
+	// ErrTeamServer is an error raised by the teamserver core code.
 	ErrTeamServer = errors.New("teamserver")
 
 	// ErrCertificate is an error related to the certificate infrastructure.

--- a/server/handler.go
+++ b/server/handler.go
@@ -1,5 +1,23 @@
 package server
 
+/*
+   team - Embedded teamserver for Go programs and CLI applications
+   Copyright (C) 2023 Reeflective
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 import (
 	"fmt"
 	"net"

--- a/server/jobs.go
+++ b/server/jobs.go
@@ -1,5 +1,23 @@
 package server
 
+/*
+   team - Embedded teamserver for Go programs and CLI applications
+   Copyright (C) 2023 Reeflective
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 import (
 	"errors"
 	"fmt"

--- a/server/log.go
+++ b/server/log.go
@@ -8,8 +8,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// NamedLogger returns a new logging "thread" which should grossly
-// indicate the package/general domain, and a more precise flow/stream.
+// NamedLogger returns a new logging "thread" with two fields (optional)
+// to indicate the package/general domain, and a more precise flow/stream.
+// The events are logged according to the teamclient logging backend setup.
 func (ts *Server) NamedLogger(pkg, stream string) *logrus.Entry {
 	return ts.log().WithFields(logrus.Fields{
 		log.PackageFieldKey: pkg,
@@ -17,7 +18,7 @@ func (ts *Server) NamedLogger(pkg, stream string) *logrus.Entry {
 	})
 }
 
-// SetLogLevel is a utility to change the logging level of the stdout logger.
+// SetLogLevel sets the logging level of teamserver loggers (excluding audit ones).
 func (ts *Server) SetLogLevel(level int) {
 	if ts.stdoutLogger == nil {
 		return
@@ -37,6 +38,10 @@ func (ts *Server) SetLogLevel(level int) {
 	}
 }
 
+// AuditLogger returns a special logger writing its event entries to an audit
+// log file (default audit.json), distinct from other teamserver log files.
+// Listener implementations will want to use this for logging various teamclient
+// application requests, with this logger used somewhere in your listener middleware.
 func (ts *Server) AuditLogger() (*logrus.Logger, error) {
 	if ts.opts.inMemory || ts.opts.noLogs {
 		return ts.log(), nil

--- a/server/log.go
+++ b/server/log.go
@@ -1,5 +1,23 @@
 package server
 
+/*
+   team - Embedded teamserver for Go programs and CLI applications
+   Copyright (C) 2023 Reeflective
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 import (
 	"fmt"
 	"path/filepath"

--- a/server/options.go
+++ b/server/options.go
@@ -20,7 +20,7 @@ type opts[server any] struct {
 	dbConfig  *db.Config
 	db        *gorm.DB
 	logger    *logrus.Logger
-	listeners []Handler[server]
+	listeners []Listener[server]
 
 	hooks map[string][]func(serv server) error
 }
@@ -55,7 +55,7 @@ func (ts *Server) apply(options ...Options) {
 		ts.self = ts.opts.listeners[0]
 	}
 
-	ts.opts.listeners = make([]Handler[any], 0)
+	ts.opts.listeners = make([]Listener[any], 0)
 }
 
 //
@@ -132,7 +132,7 @@ func WithLogger(logger *logrus.Logger) Options {
 // *** Server network/RPC options ***
 //
 
-func WithListener(ln Handler[any]) Options {
+func WithListener(ln Listener[any]) Options {
 	return func(opts *opts[any]) {
 		opts.listeners = append(opts.listeners, ln)
 	}

--- a/server/options.go
+++ b/server/options.go
@@ -1,5 +1,23 @@
 package server
 
+/*
+   team - Embedded teamserver for Go programs and CLI applications
+   Copyright (C) 2023 Reeflective
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 import (
 	"github.com/reeflective/team/internal/db"
 	"github.com/sirupsen/logrus"

--- a/server/users.go
+++ b/server/users.go
@@ -1,5 +1,23 @@
 package server
 
+/*
+   team - Embedded teamserver for Go programs and CLI applications
+   Copyright (C) 2023 Reeflective
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
 import (
 	"crypto/rand"
 	"crypto/sha256"

--- a/transports/grpc/server/middleware.go
+++ b/transports/grpc/server/middleware.go
@@ -80,7 +80,7 @@ func LogMiddleware(s *server.Server) ([]grpc.ServerOption, error) {
 func TLSAuthMiddleware(s *server.Server) ([]grpc.ServerOption, error) {
 	var options []grpc.ServerOption
 
-	tlsConfig, err := s.GetUserTLSConfig()
+	tlsConfig, err := s.UsersTLSConfig()
 	if err != nil {
 		return nil, err
 	}

--- a/transports/grpc/server/server.go
+++ b/transports/grpc/server/server.go
@@ -51,7 +51,7 @@ type handler struct {
 // 	return nil, nil
 // }
 
-func NewTeam(opts ...grpc.ServerOption) (teamserver.Handler[any], team.Client, teamclient.Dialer[any]) {
+func NewTeam(opts ...grpc.ServerOption) (teamserver.Listener[any], team.Client, teamclient.Dialer[any]) {
 	listener := &handler{
 		mutex: &sync.RWMutex{},
 	}


### PR DESCRIPTION
- Refactor most of the code into an internal directory
- Adapt server code with internal one
- Refactor client code with internal one.
- Refactor examples and adapt commands
- Refactor cobra command entrypoints and self-server
- Refactor examples
- Refactor examples
- Refactors
- Change the directories used by the teamserver apps
- Further tidy and fixes
- Refactor and cleanup log code
- Cleanup log code
- Fix logs
- Try to fix a weird connection issue
- Fix TLS keylogger
- Refactor logs, renamings, etc.
- Go mod tidy of commits to follow: - Rewrite the library with pluggable transports, clients &| server - Try to cleanup the code a bit, and fix things.
- Server refactoring with grpc backend out of there.
- Add server/transports/ directory with pluggable transports.
- Refactor log package and use file perm checks before starting servers/client/ Add a core package, which contains root-root version/users calls, and might also contain listener jobs management....
- Adapt command code with changes
- Same refactorings/cleanups client-side
- Add client/server options
- Fix logs in server
- Remove redundant config loadings
- Fixes in server
- Remove all calls to panic and replace with errors + multiple cleanups and fixes
- Database logger back
- Cleanup log calls
- Change errors formatting directives
- Cleanups
- Fix to server init to early
- Fix in-memory grpc
- Refactor code
- Cleanup commands
- Big refactoring and refining of APIs:
- First refactoring and harmonization of errors everywhere
- Change config file names/extensions.
- Move all grpc code from core
- Use commands stdout when possible
- Further cleanup/changes to log and fixes to certs
- Enhance/fix command tree
- Harmonize client logging code
- Harmonize server log code + fixes to client log
- Ensure client/server options are applied correctly
- Add job management, refactor serve start functions
- Add job control, harmonize listener serving API/internals
- Start adding job control to commands, display status + enhancements
- Harmonize logging for client: - Synchronize with io when used in commands. - Log all errors before being returned by public API. - Cleanup
- Fixes to client logging
- Harmonize server logging and sync with command io
- Refactor internal log stdio
- Split stdout/stderr logging
- Add golangci.yml file + update go.mod
- Update README
- Add github workflows
- Update go build actions
- Lint client code
- Change branch name in actions
- Fix generate
- Update workflows try to fix them
- Fixes
- Fixes to workflows
- Fix formattings
- Still
- Lint server
- Second lint pass on the server
- Fixes
- Fixes/finish client disconnect
- Move constants internally
- Ensure database is ignited where needed, even in-memory
- Ensure most of in-memory run mode code logic (certs remain)
- Finish in-memory code
- Start refactoring everything fs-related with memfs/osfs
- The client now works fully in-memory
- Add in-memory filesystem interface.
- Adapt filesystem code in client/server
- Cleanup previous commits
- Fixes
- Fix user last-seen display
- Fix users display last-seen
- Listeners completion + fixes
- Use stderr where possible, fix newlines
- Fix most logging stuff
- Several stuff: - Add most status command output - Fix listeners status - Refactors
- Harmonize listener instantiation & interface calls
- Fixes in cert code, cleanups
- Fixed duplicate logs, cleanups
- Tidy options API, fixes to audit log
- Fix status strings
- Cleanup/refactor/expose grpc transport code
- Fix logging level flag
- Use go_sqlite default without tags, rename example dirs
- Fix itoa stuff
- Fix github actions
- Fix itoa
- Fix default db build tags
- Fix itoa again
- Write comments for client package
- Add headers to all internal files + comments doc for FS
- Cleanup and comment certs package
- Cleanup db package
- Cleanup/fix/comment log package
- Comment version/tls packages
- Cleanup/command client command tree
- Fix comments in client/internal
- Comment all server package
- Add headers
