### PR TITLE
dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ or around enhancing its interoperability with as much Go code/programs as possib
 - [ ] Use viper for configs.
 - [ ] Use afero filesystem.
 - [ ] Add support for encrypted sqlite by default.
-- [ ] Simpler listener/dialer backend interfaces, if it appears needed.
+- [ ] Encrypt in-memory channels, or add option for it.
+- [ ] Simpler/different listener/dialer backend interfaces, if it appears needed.
 - [ ] Abstract away the client-side authentication, for pluggable auth/credential models.
 - [ ] Replace logrus entirely and restructure behind a single package used by both client/server.
 - [ ] Review/refine/strenghen the dialer/listener init/close/start process, if it appears needed.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,11 @@
 
 -----
 
-## Examples
+## CLI examples (users)
+
+-----
+
+## API examples (developers)
 
 -----
 

--- a/client/commands/commands.go
+++ b/client/commands/commands.go
@@ -52,13 +52,12 @@ func Generate(cli *client.Client) *cobra.Command {
 // If the client is connected, nothing happens and its current connection reused.
 //
 // Feel free to use this function as a model for your own teamclient pre-runners.
-func PreRun(teamclient *client.Client) command.CobraRunnerE {
+func PreRun(teamclient *client.Client, opts ...client.Options) command.CobraRunnerE {
 	return func(cmd *cobra.Command, args []string) error {
-		// Client settings.
 		teamclient.SetLogWriter(cmd.OutOrStdout(), cmd.ErrOrStderr())
 
 		// Ensure we are connected or do it.
-		return teamclient.Connect()
+		return teamclient.Connect(opts...)
 	}
 }
 
@@ -67,13 +66,14 @@ func PreRun(teamclient *client.Client) command.CobraRunnerE {
 // connection is kept open. This pre-runner is thus useful for console apps.
 //
 // Feel free to use this function as a model for your own teamclient pre-runners.
-func PreRunNoDisconnect(teamclient *client.Client) command.CobraRunnerE {
+func PreRunNoDisconnect(teamclient *client.Client, opts ...client.Options) command.CobraRunnerE {
 	return func(cmd *cobra.Command, args []string) error {
-		// Client settings.
 		teamclient.SetLogWriter(cmd.OutOrStdout(), cmd.ErrOrStderr())
 
+		opts = append(opts, client.WithNoDisconnect())
+
 		// The NoDisconnect will prevent teamclient.Disconnect() to close the conn.
-		return teamclient.Connect(client.WithNoDisconnect())
+		return teamclient.Connect(opts...)
 	}
 }
 

--- a/example/teamclient/main.go
+++ b/example/teamclient/main.go
@@ -50,3 +50,5 @@ func main() {
 		log.Fatal(err)
 	}
 }
+
+func mainPreCommands() {}

--- a/example/teamclient/main.go
+++ b/example/teamclient/main.go
@@ -3,19 +3,19 @@ package main
 import (
 	"log"
 
-	teamclient "github.com/reeflective/team/client"
+	"github.com/reeflective/team/client"
 	"github.com/reeflective/team/client/commands"
 	grpc "github.com/reeflective/team/transports/grpc/client"
 	"github.com/rsteube/carapace"
 )
 
 func main() {
-	client := grpc.NewTeamClient()
+	gTeamclient := grpc.NewTeamClient()
 
 	// Create a new teamserver client, without any working
 	// gRPC connection at this stage. We could pass some options
 	// to it if we want to customize behavior.
-	teamclient, err := teamclient.New("teamserver", client, teamclient.WithDialer(client))
+	teamclient, err := client.New("teamserver", gTeamclient, client.WithDialer(gTeamclient))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/example/teamserver/main.go
+++ b/example/teamserver/main.go
@@ -37,7 +37,7 @@ func main() {
 
 	// 2) Teamclients & dialers
 	//
-	// Although the teamserver above can be a gTeamclient of itself without further addings,
+	// Although the teamserver above can be a client of itself without further addings,
 	// we want to use the same backend for both remote and local gRPC app teamclients.
 	// We thus generate a local gTeamclient (almost identical to remote ones), which can
 	// use the generic gRPC listener backend.
@@ -45,7 +45,7 @@ func main() {
 
 	// Create a new teamclient core, just like we would in a client-only binary application.
 	// We specify which dialing backend we want (in this case, our custom gRPC dialer/RPC client)
-	// Note here that our gRPC client is concrete type which implements two different interfaces
+	// Note here that our gRPC client is a concrete type which implements two different interfaces
 	// at once, so that our teamclient core is in effect only-gRPC configured/enabled.
 	teamclient, err := client.New(teamserver.Name(), gTeamclient, client.WithDialer(gTeamclient))
 	if err != nil {

--- a/example/teamserver/main.go
+++ b/example/teamserver/main.go
@@ -76,8 +76,34 @@ func main() {
 	}
 }
 
+func mainSmallGRPC() {
+	// Server
+	gTeamserver := grpc.NewListener()
+
+	teamserver, err := server.New("teamserver", server.WithListener(gTeamserver))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Client
+	gTeamclient := grpc.NewClientFrom(gTeamserver)
+
+	teamclient := teamserver.Self(client.WithDialer(gTeamclient))
+
+	// Commands
+	serverCmds := commands.Generate(teamserver, teamclient)
+
+	// Run
+	carapace.Gen(serverCmds)
+
+	err = serverCmds.Execute()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
 func mainSmallest() {
-	teamserver, err := server.New("smallserver", nil)
+	teamserver, err := server.New("smallserver")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -117,7 +143,6 @@ func mainInMemory() {
 
 func mainIntegrated() {}
 
-func mainCustom() {
-}
+func mainCustom() {}
 
 func mainNoCommands() {}

--- a/server/commands/commands.go
+++ b/server/commands/commands.go
@@ -73,10 +73,14 @@ func Generate(teamserver *server.Server, teamclient *client.Client) *cobra.Comma
 // makes this runner able to be ran in closed-loop consoles.
 //
 // Feel free to use this function as a model for your own teamserver pre-runners.
-func PreRun(teamserver *server.Server, teamclient *client.Client) command.CobraRunnerE {
+func PreRun(serv *server.Server, cli *client.Client, opts ...server.Options) command.CobraRunnerE {
 	return func(cmd *cobra.Command, args []string) error {
+		if err := serv.Serve(); err != nil {
+			return err
+		}
+
 		// And connect the client locally, only needed.
-		return teamserver.Serve(teamclient)
+		return cli.Connect(client.WithLocalDialer())
 	}
 }
 

--- a/server/core.go
+++ b/server/core.go
@@ -64,7 +64,7 @@ type Server struct {
 	// Core
 	name     string     // Name of the application using the teamserver.
 	homeDir  string     // APP_ROOT_DIR var, evaluated once when creating the server.
-	opts     *opts[any] // Server options
+	opts     *opts      // Server options
 	fs       *assets.FS // Server filesystem, on-disk or embedded
 	initOpts sync.Once  // Some options can only be set once when creating the server.
 
@@ -79,10 +79,10 @@ type Server struct {
 	dbInit     sync.Once      // A single database can be used in a teamserver lifetime.
 
 	// Listeners and job control
-	initServe sync.Once                // Some options can only have an effect at first start.
-	self      Listener[any]            // The default listener stack used by the teamserver.
-	handlers  map[string]Listener[any] // Other listeners available by name.
-	jobs      *jobs                    // Listeners job control
+	initServe sync.Once           // Some options can only have an effect at first start.
+	self      Listener            // The default listener stack used by the teamserver.
+	handlers  map[string]Listener // Other listeners available by name.
+	jobs      *jobs               // Listeners job control
 }
 
 // New creates a new teamserver for the provided application name.
@@ -107,7 +107,7 @@ func New(application string, options ...Options) (*Server, error) {
 		opts:       newDefaultOpts(),
 		userTokens: &sync.Map{},
 		jobs:       newJobs(),
-		handlers:   make(map[string]Listener[any]),
+		handlers:   make(map[string]Listener),
 	}
 
 	server.apply(options...)
@@ -155,6 +155,8 @@ func (ts *Server) Name() string {
 // of the application using this teamserver.
 // See the server.Listener and client.Dialer types documentation for more.
 func (ts *Server) Self(opts ...client.Options) *client.Client {
+	opts = append(opts, client.WithLocalDialer())
+
 	teamclient, _ := client.New(ts.Name(), ts, opts...)
 
 	return teamclient

--- a/server/db.go
+++ b/server/db.go
@@ -36,6 +36,16 @@ const (
 	maxOpenConns = 100
 )
 
+// Database returns a new teamserver database session, which may not be nil:
+// at worst, this database will be an in-memory one. The default is a file-
+// based Sqlite database in the teamserver directory, but it might be a
+// specific database passed through options.
+func (ts *Server) Database() *gorm.DB {
+	return ts.db.Session(&gorm.Session{
+		FullSaveAssociations: true,
+	})
+}
+
 // DatabaseConfig returns the server database backend configuration struct.
 // If configuration could be found on disk, the default Sqlite file-based
 // database is returned, with app-corresponding file paths.

--- a/server/jobs.go
+++ b/server/jobs.go
@@ -21,6 +21,7 @@ package server
 import (
 	"errors"
 	"fmt"
+	"net"
 	"sync"
 )
 
@@ -189,7 +190,7 @@ func (ts *Server) ListenerStartPersistents() error {
 	return nil
 }
 
-func (ts *Server) addListenerJob(listenerID, host string, port int, ln Listener[any]) {
+func (ts *Server) addListenerJob(listenerID, name, host string, port int, ln net.Listener) {
 	log := ts.NamedLogger("teamserver", "listeners")
 
 	if listenerID == "" {
@@ -207,7 +208,7 @@ func (ts *Server) addListenerJob(listenerID, host string, port int, ln Listener[
 
 	listener := &job{
 		ID:          listenerID,
-		Name:        ln.Name(),
+		Name:        name,
 		Description: laddr,
 		kill:        make(chan bool),
 	}
@@ -216,7 +217,7 @@ func (ts *Server) addListenerJob(listenerID, host string, port int, ln Listener[
 		<-listener.kill
 
 		// Kills listener goroutines but NOT connections.
-		log.Infof("Stopping teamserver %s listener (%s)", ln.Name(), listener.ID)
+		log.Infof("Stopping teamserver %s listener (%s)", name, listener.ID)
 		ln.Close()
 
 		ts.jobs.active.LoadAndDelete(listener.ID)

--- a/transports/grpc/client/client.go
+++ b/transports/grpc/client/client.go
@@ -130,7 +130,7 @@ func (h *Teamclient) Dial() (rpcClient any, err error) {
 
 	h.rpc = proto.NewTeamClient(h.conn)
 
-	return h.rpc, nil
+	return h.conn, nil
 }
 
 // Close implements team/client.Dialer.Close(), and closes the gRPC client connection.

--- a/transports/grpc/client/client.go
+++ b/transports/grpc/client/client.go
@@ -88,7 +88,7 @@ func NewTeamClient(opts ...grpc.DialOption) *Teamclient {
 	return client
 }
 
-// Init implements client.Dialer.Init(c).
+// Init implements team/client.Dialer.Init(c).
 // This implementation asks the teamclient core for its remote server
 // configuration, and uses it to load a set of Mutual TLS dialing options.
 func (h *Teamclient) Init(cli *client.Client) error {
@@ -113,7 +113,7 @@ func (h *Teamclient) Init(cli *client.Client) error {
 	return nil
 }
 
-// Dial implements client.Dialer.Dial().
+// Dial implements team/client.Dialer.Dial().
 // It uses the teamclient remote server configuration as a target of a dial call.
 // If the connection is successful, the teamclient registers a proto.Teamclient
 // RPC around its client connection, to provide the core teamclient functionality.
@@ -133,7 +133,7 @@ func (h *Teamclient) Dial() (rpcClient any, err error) {
 	return h.rpc, nil
 }
 
-// Close implements client.Dialer.Close(), and closes the gRPC client connection.
+// Close implements team/client.Dialer.Close(), and closes the gRPC client connection.
 func (h *Teamclient) Close() error {
 	return h.conn.Close()
 }

--- a/transports/grpc/server/server.go
+++ b/transports/grpc/server/server.go
@@ -93,13 +93,13 @@ func NewClientFrom(server *Teamserver, opts ...grpc.DialOption) *clientConn.Team
 	return clientConn.NewTeamClient(opts...)
 }
 
-// Name immplements server.Handler.Name().
+// Name immplements team/server.Handler.Name().
 // It indicates the transport/rpc stack, in this case "gRPC".
 func (h *Teamserver) Name() string {
 	return "gRPC"
 }
 
-// Init implements server.Handler.Init().
+// Init implements team/server.Handler.Init().
 // It is used to initialize the listener with the correct TLS credentials
 // middleware (or absence of if about to serve an in-memory connection).
 func (h *Teamserver) Init(serv *teamserver.Server) (err error) {
@@ -121,7 +121,7 @@ func (h *Teamserver) Init(serv *teamserver.Server) (err error) {
 	return nil
 }
 
-// Listen implements server.Handler.Listen().
+// Listen implements team/server.Handler.Listen().
 // It starts listening on a network address for incoming gRPC clients.
 // If the teamserver has previously been given an in-memory connection,
 // it returns it as the listener without errors.
@@ -142,7 +142,7 @@ func (h *Teamserver) Listen(addr string) (net.Listener, error) {
 	return ln, nil
 }
 
-// Serve implements server.Handler.Serve().
+// Serve implements team/server.Handler.Serve().
 // The listener function argument is the one this Teamserver returned with Listen().
 // Once acquired and the gRPC server started around this listener, the proto.TeamServer
 // is registered to it and served to incoming clients.
@@ -195,10 +195,9 @@ func (h *Teamserver) Serve(listener net.Listener) (any, error) {
 	return grpcServer, nil
 }
 
-// Close implements server.Handler.Close().
-//
+// Close implements team/server.Handler.Close().
 // In this implementation, the function does nothing. Thus the underlying
-// *grpc.Server .Shutdown() method is not called, and only the listener
+// *grpc.Server.Shutdown() method is not called, and only the listener
 // will be closed by the server automatically when using CloseListener().
 //
 // This is probably not optimal from a resource usage standpoint, but currently it

--- a/transports/grpc/server/server.go
+++ b/transports/grpc/server/server.go
@@ -57,6 +57,8 @@ type Teamserver struct {
 	options []grpc.ServerOption
 	conn    *bufconn.Listener
 	mutex   *sync.RWMutex
+
+	hooks []func(server *grpc.Server) error
 }
 
 // NewListener is a simple constructor returning a teamserver loaded with the
@@ -99,6 +101,13 @@ func (h *Teamserver) Name() string {
 	return "gRPC"
 }
 
+// PostServe register one or more hook functions to be ran on the server
+// before it is served to the listener. These hooks should naturally be
+// used to register additional services to it.
+func (h *Teamserver) PostServe(hooks ...func(server *grpc.Server) error) {
+	h.hooks = append(h.hooks, hooks...)
+}
+
 // Init implements team/server.Handler.Init().
 // It is used to initialize the listener with the correct TLS credentials
 // middleware (or absence of if about to serve an in-memory connection).
@@ -125,53 +134,44 @@ func (h *Teamserver) Init(serv *teamserver.Server) (err error) {
 // It starts listening on a network address for incoming gRPC clients.
 // If the teamserver has previously been given an in-memory connection,
 // it returns it as the listener without errors.
-func (h *Teamserver) Listen(addr string) (net.Listener, error) {
+func (h *Teamserver) Listen(addr string) (ln net.Listener, err error) {
 	rpcLog := h.NamedLogger("transport", "mTLS")
 
-	if h.conn != nil {
-		return h.conn, nil
-	}
-
-	rpcLog.Infof("Starting gRPC TLS listener on %s", addr)
-
-	ln, err := net.Listen("tcp", addr)
-	if err != nil {
-		return nil, err
-	}
-
-	return ln, nil
-}
-
-// Serve implements team/server.Handler.Serve().
-// The listener function argument is the one this Teamserver returned with Listen().
-// Once acquired and the gRPC server started around this listener, the proto.TeamServer
-// is registered to it and served to incoming clients.
-func (h *Teamserver) Serve(listener net.Listener) (any, error) {
-	rpcLog := h.NamedLogger("transport", "grpc")
-
-	// Encryption.
-	h.mutex.Lock()
+	// Only wrap the connection in TLS when remote.
+	// In-memory connection are not authenticated.
 	if h.conn == nil {
+		ln, err = net.Listen("tcp", addr)
+		if err != nil {
+			return nil, err
+		}
+
+		// Encryption.
 		tlsOptions, err := TLSAuthMiddlewareOptions(h.Server)
 		if err != nil {
 			return nil, err
 		}
 
 		h.options = append(h.options, tlsOptions...)
-
-		rpcLog.Infof("Serving gRPC teamserver on %s", listener.Addr())
+	} else {
+		h.mutex.Lock()
+		ln = h.conn
+		h.conn = nil
+		h.mutex.Unlock()
 	}
-	h.mutex.Unlock()
 
 	grpcServer := grpc.NewServer(h.options...)
 
-	// If we already have an in-memory listener, use it.
-	h.mutex.Lock()
-	if h.conn != nil {
-		listener = h.conn
-		h.conn = nil
+	// Register the core teamserver service
+	proto.RegisterTeamServer(grpcServer, newServer(h.Server))
+
+	for _, hook := range h.hooks {
+		if err := hook(grpcServer); err != nil {
+			rpcLog.Errorf("service bind error: %s", err)
+			return nil, err
+		}
 	}
-	h.mutex.Unlock()
+
+	rpcLog.Infof("Serving gRPC teamserver on %s", ln.Addr())
 
 	// Start serving the listener
 	go func() {
@@ -182,17 +182,14 @@ func (h *Teamserver) Serve(listener net.Listener) (any, error) {
 			}
 		}()
 
-		if err := grpcServer.Serve(listener); err != nil {
+		if err := grpcServer.Serve(ln); err != nil {
 			rpcLog.Errorf("gRPC server exited with error: %v", err)
 		} else {
 			panicked = false
 		}
 	}()
 
-	// Register the core teamserver service
-	proto.RegisterTeamServer(grpcServer, newServer(h.Server))
-
-	return grpcServer, nil
+	return ln, nil
 }
 
 // Close implements team/server.Handler.Close().


### PR DESCRIPTION
- Refactor most of the code into an internal directory
- Adapt server code with internal one
- Refactor client code with internal one.
- Refactor examples and adapt commands
- Refactor cobra command entrypoints and self-server
- Refactor examples
- Refactor examples
- Refactors
- Change the directories used by the teamserver apps
- Further tidy and fixes
- Refactor and cleanup log code
- Cleanup log code
- Fix logs
- Try to fix a weird connection issue
- Fix TLS keylogger
- Refactor logs, renamings, etc.
- Go mod tidy of commits to follow: - Rewrite the library with pluggable transports, clients &| server - Try to cleanup the code a bit, and fix things.
- Server refactoring with grpc backend out of there.
- Add server/transports/ directory with pluggable transports.
- Refactor log package and use file perm checks before starting servers/client/ Add a core package, which contains root-root version/users calls, and might also contain listener jobs management....
- Adapt command code with changes
- Same refactorings/cleanups client-side
- Add client/server options
- Fix logs in server
- Remove redundant config loadings
- Fixes in server
- Remove all calls to panic and replace with errors + multiple cleanups and fixes
- Database logger back
- Cleanup log calls
- Change errors formatting directives
- Cleanups
- Fix to server init to early
- Fix in-memory grpc
- Refactor code
- Cleanup commands
- Big refactoring and refining of APIs:
- First refactoring and harmonization of errors everywhere
- Change config file names/extensions.
- Move all grpc code from core
- Use commands stdout when possible
- Further cleanup/changes to log and fixes to certs
- Enhance/fix command tree
- Harmonize client logging code
- Harmonize server log code + fixes to client log
- Ensure client/server options are applied correctly
- Add job management, refactor serve start functions
- Add job control, harmonize listener serving API/internals
- Start adding job control to commands, display status + enhancements
- Harmonize logging for client: - Synchronize with io when used in commands. - Log all errors before being returned by public API. - Cleanup
- Fixes to client logging
- Harmonize server logging and sync with command io
- Refactor internal log stdio
- Split stdout/stderr logging
- Add golangci.yml file + update go.mod
- Update README
- Add github workflows
- Update go build actions
- Lint client code
- Change branch name in actions
- Fix generate
- Update workflows try to fix them
- Fixes
- Fixes to workflows
- Fix formattings
- Still
- Lint server
- Second lint pass on the server
- Fixes
- Fixes/finish client disconnect
- Move constants internally
- Ensure database is ignited where needed, even in-memory
- Ensure most of in-memory run mode code logic (certs remain)
- Finish in-memory code
- Start refactoring everything fs-related with memfs/osfs
- The client now works fully in-memory
- Add in-memory filesystem interface.
- Adapt filesystem code in client/server
- Cleanup previous commits
- Fixes
- Fix user last-seen display
- Fix users display last-seen
- Listeners completion + fixes
- Use stderr where possible, fix newlines
- Fix most logging stuff
- Several stuff: - Add most status command output - Fix listeners status - Refactors
- Harmonize listener instantiation & interface calls
- Fixes in cert code, cleanups
- Fixed duplicate logs, cleanups
- Tidy options API, fixes to audit log
- Fix status strings
- Cleanup/refactor/expose grpc transport code
- Fix logging level flag
- Use go_sqlite default without tags, rename example dirs
- Fix itoa stuff
- Fix github actions
- Fix itoa
- Fix default db build tags
- Fix itoa again
- Write comments for client package
- Add headers to all internal files + comments doc for FS
- Cleanup and comment certs package
- Cleanup db package
- Cleanup/fix/comment log package
- Comment version/tls packages
- Cleanup/command client command tree
- Fix comments in client/internal
- Comment all server package
- Add headers
- Comment/cleanup options API
- Cleanup and tighten server API
- Comment and cleanup gRPC client package
- Comment all grpc transport client/server code
- Regenerate gRPC stubs
- Cleanup comments in client/server command trees
- Wire up home dir option.
- Fix homedir wiring, systemd version print
- Fix client-side grpc logging middleware
- Fixes, cleanups
- README
- Cleanup/comment teamserver example gRPC, comment root types
- README
- README
- Comment teamclient example
