### PR TITLE
dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,19 @@
 
 ## Status
 
+The Command-Line and Application-Programming Interfaces of this library are unlikely to change
+much in the future, and should be considered mostly stable. These might grow a little bit, but
+will not shrink, as they been already designed to be as minimal as they could be.
+
+In particular, `client.Options` and `server.Options` APIs might grow, so that new features/behaviors
+can be integrated without the need for the teamclients and teamservers types APIs to change.
+
+The section **Possible Enhancements** below includes 9 points, which should grossly be equal
+to 9 minor releases (`0.1.0`, `0.2.0`, `0.3.0`, etc...), ending up in `v1.0.0`.
+
+- Please open a PR or an issue if you face any bug, it will be promptly resolved.
+- New features and/or PRs are welcome if they are likely to be useful to most users.
+
 -----
 
 ## Possible enhancements

--- a/README.md
+++ b/README.md
@@ -103,3 +103,5 @@ or around enhancing its interoperability with as much Go code/programs as possib
 - [ ] Abstract away the client-side authentication, for pluggable auth/credential models.
 - [ ] Replace logrus entirely and restructure behind a single package used by both client/server.
 - [ ] Review/refine/strenghen the dialer/listener init/close/start process, if it appears needed.
+- [ ] `teamclient update` downloads latest version of the server binary + method to `team.Client` for it.
+

--- a/client/commands/commands.go
+++ b/client/commands/commands.go
@@ -90,7 +90,6 @@ func clientCommands(cli *client.Client) *cobra.Command {
 	teamCmd := &cobra.Command{
 		Use:          "teamclient",
 		Short:        "Client-only teamserver commands (import configs, show users, etc)",
-		GroupID:      command.TeamServerGroup,
 		SilenceUsage: true,
 	}
 
@@ -198,6 +197,46 @@ func ConfigsCompleter(cli *client.Client, filePath, ext, tag string, noSelf bool
 
 		return configsAction.Tag(tag)
 	}
+}
+
+// ConfigsAppCompleter completes file paths to the current application configs.
+func ConfigsAppCompleter(cli *client.Client, tag string) carapace.Action {
+	return carapace.ActionCallback(func(ctx carapace.Context) carapace.Action {
+		var compErrors []carapace.Action
+
+		configPath := cli.ConfigsDir()
+
+		files, err := os.ReadDir(configPath)
+		if err != nil {
+			compErrors = append(compErrors, carapace.ActionMessage("failed to list user directories: %s", err))
+		}
+
+		var results []string
+
+		for _, file := range files {
+			if !strings.HasSuffix(file.Name(), command.ClientConfigExt) {
+				continue
+			}
+
+			filePath := filepath.Join(configPath, file.Name())
+
+			cfg, err := cli.ReadConfig(filePath)
+			if err != nil || cfg == nil {
+				continue
+			}
+
+			results = append(results, filePath)
+			results = append(results, fmt.Sprintf("[%s] %s:%d", cfg.User, cfg.Host, cfg.Port))
+		}
+
+		configsAction := carapace.ActionValuesDescribed(results...).StyleF(getConfigStyle(command.ClientConfigExt))
+
+		return carapace.Batch(append(
+			compErrors,
+			configsAction.Tag(tag),
+			carapace.ActionFiles())...,
+		).ToA()
+	})
 }
 
 func isConfigDir(cli *client.Client, dir fs.DirEntry, noSelf bool) bool {

--- a/example/teamserver/main.go
+++ b/example/teamserver/main.go
@@ -123,12 +123,6 @@ func mainSmallest() {
 	}
 }
 
-// Run our teamserver binary.
-// Here we are executing the simple teamserver command tree, but anything is possible:
-// // - We could "forget" about our teamserver because we have a blocking call somewhere,
-// // - Let one of the commands to be executed and exit, without listening anywhere.
-// // - Many, many different variants in which you can keep working below.
-
 func mainInMemory() {
 	var clientOpts []client.Options
 	clientOpts = append(clientOpts,

--- a/server/commands/commands.go
+++ b/server/commands/commands.go
@@ -19,6 +19,8 @@ package commands
 */
 
 import (
+	"fmt"
+
 	"github.com/reeflective/team/client"
 	cli "github.com/reeflective/team/client/commands"
 	"github.com/reeflective/team/internal/command"
@@ -33,13 +35,13 @@ import (
 // This is so that all CLI applications which can be a teamserver can also be a client of their own.
 //
 // ** Commands do:
-//   - Ensure they are connected to a server instance (in memory).
 //   - Work even if the teamserver/client returns errors: those are returned &| printed &| logged.
 //   - Use the cobra utilities OutOrStdout(), ErrOrStdErr(), ... for all and every command output.
 //   - Have attached completions for users/listeners/config files of all sorts, and other things.
 //   - Have the ability to be ran in closed-loop console applications ("single runtime shell").
 //
 // ** Commands do NOT:
+//   - Ensure they are connected to a server instance before running (in memory).
 //   - Call os.Exit() anywhere, thus will not exit the program embedding them.
 //   - Ignite/start the teamserver core/filesystem/backends before they absolutely need to.
 //     Consequently, do not touch the filesystem until they absolutely need to.
@@ -51,21 +53,10 @@ func Generate(teamserver *server.Server, teamclient *client.Client) *cobra.Comma
 	// On top, they need a listener in memory.
 	servCmds := serverCommands(teamserver, teamclient)
 
-	for _, cmd := range servCmds.Commands() {
-		cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
-			return teamserver.Serve(teamclient)
-		}
-	}
-
 	// We bind the same runners to the client-side commands.
 	cliCmds := cli.Generate(teamclient)
 	cliCmds.Use = "client"
-
-	for _, cmd := range cliCmds.Commands() {
-		cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
-			return teamserver.Serve(teamclient)
-		}
-	}
+	cliCmds.GroupID = command.TeamServerGroup
 
 	servCmds.AddCommand(cliCmds)
 
@@ -75,7 +66,7 @@ func Generate(teamserver *server.Server, teamclient *client.Client) *cobra.Comma
 func serverCommands(server *server.Server, client *client.Client) *cobra.Command {
 	teamCmd := &cobra.Command{
 		Use:          "teamserver",
-		Short:        "Manage the application server-side teamserver and users",
+		Short:        fmt.Sprintf("Manage the %s teamserver and users", server.Name()),
 		SilenceUsage: true,
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -27,6 +27,7 @@ import (
 	"runtime/debug"
 	"syscall"
 
+	"github.com/reeflective/team/client"
 	"github.com/reeflective/team/internal/certs"
 )
 
@@ -76,7 +77,7 @@ type Listener interface {
 // the first one to have been registered, or the only one registered at all).
 // It the responsibility of any teamclients produced by the teamserver.Self()
 // method to call their Connect() method: the server will answer.
-func (ts *Server) Serve(opts ...Options) error {
+func (ts *Server) Serve(cli *client.Client, opts ...Options) error {
 	if ts.self == nil {
 		return ErrNoListener
 	}
@@ -84,7 +85,12 @@ func (ts *Server) Serve(opts ...Options) error {
 	// Some errors might come from user-provided hooks,
 	// so we don't wrap errors again, our own errors
 	// have been prepared accordingly in this call.
-	return ts.serve(ts.self, "", "", 0, opts...)
+	err := ts.serve(ts.self, "", "", 0, opts...)
+	if err != nil {
+		return err
+	}
+
+	return cli.Connect(client.WithLocalDialer())
 }
 
 // ServeDaemon is a blocking call which starts the teamserver as daemon process, using

--- a/transports/grpc/server/server.go
+++ b/transports/grpc/server/server.go
@@ -101,7 +101,7 @@ func (h *Teamserver) Name() string {
 	return "gRPC"
 }
 
-// PostServe register one or more hook functions to be ran on the server
+// PostServe registers one or more hook functions to be ran on the server
 // before it is served to the listener. These hooks should naturally be
 // used to register additional services to it.
 func (h *Teamserver) PostServe(hooks ...func(server *grpc.Server) error) {


### PR DESCRIPTION
- Refactor most of the code into an internal directory
- Adapt server code with internal one
- Refactor client code with internal one.
- Refactor examples and adapt commands
- Refactor cobra command entrypoints and self-server
- Refactor examples
- Refactor examples
- Refactors
- Change the directories used by the teamserver apps
- Further tidy and fixes
- Refactor and cleanup log code
- Cleanup log code
- Fix logs
- Try to fix a weird connection issue
- Fix TLS keylogger
- Refactor logs, renamings, etc.
- Go mod tidy of commits to follow: - Rewrite the library with pluggable transports, clients &| server - Try to cleanup the code a bit, and fix things.
- Server refactoring with grpc backend out of there.
- Add server/transports/ directory with pluggable transports.
- Refactor log package and use file perm checks before starting servers/client/ Add a core package, which contains root-root version/users calls, and might also contain listener jobs management....
- Adapt command code with changes
- Same refactorings/cleanups client-side
- Add client/server options
- Fix logs in server
- Remove redundant config loadings
- Fixes in server
- Remove all calls to panic and replace with errors + multiple cleanups and fixes
- Database logger back
- Cleanup log calls
- Change errors formatting directives
- Cleanups
- Fix to server init to early
- Fix in-memory grpc
- Refactor code
- Cleanup commands
- Big refactoring and refining of APIs:
- First refactoring and harmonization of errors everywhere
- Change config file names/extensions.
- Move all grpc code from core
- Use commands stdout when possible
- Further cleanup/changes to log and fixes to certs
- Enhance/fix command tree
- Harmonize client logging code
- Harmonize server log code + fixes to client log
- Ensure client/server options are applied correctly
- Add job management, refactor serve start functions
- Add job control, harmonize listener serving API/internals
- Start adding job control to commands, display status + enhancements
- Harmonize logging for client: - Synchronize with io when used in commands. - Log all errors before being returned by public API. - Cleanup
- Fixes to client logging
- Harmonize server logging and sync with command io
- Refactor internal log stdio
- Split stdout/stderr logging
- Add golangci.yml file + update go.mod
- Update README
- Add github workflows
- Update go build actions
- Lint client code
- Change branch name in actions
- Fix generate
- Update workflows try to fix them
- Fixes
- Fixes to workflows
- Fix formattings
- Still
- Lint server
- Second lint pass on the server
- Fixes
- Fixes/finish client disconnect
- Move constants internally
- Ensure database is ignited where needed, even in-memory
- Ensure most of in-memory run mode code logic (certs remain)
- Finish in-memory code
- Start refactoring everything fs-related with memfs/osfs
- The client now works fully in-memory
- Add in-memory filesystem interface.
- Adapt filesystem code in client/server
- Cleanup previous commits
- Fixes
- Fix user last-seen display
- Fix users display last-seen
- Listeners completion + fixes
- Use stderr where possible, fix newlines
- Fix most logging stuff
- Several stuff: - Add most status command output - Fix listeners status - Refactors
- Harmonize listener instantiation & interface calls
- Fixes in cert code, cleanups
- Fixed duplicate logs, cleanups
- Tidy options API, fixes to audit log
- Fix status strings
- Cleanup/refactor/expose grpc transport code
- Fix logging level flag
- Use go_sqlite default without tags, rename example dirs
- Fix itoa stuff
- Fix github actions
- Fix itoa
- Fix default db build tags
- Fix itoa again
- Write comments for client package
- Add headers to all internal files + comments doc for FS
- Cleanup and comment certs package
- Cleanup db package
- Cleanup/fix/comment log package
- Comment version/tls packages
- Cleanup/command client command tree
- Fix comments in client/internal
- Comment all server package
- Add headers
- Comment/cleanup options API
- Cleanup and tighten server API
- Comment and cleanup gRPC client package
- Comment all grpc transport client/server code
- Regenerate gRPC stubs
- Cleanup comments in client/server command trees
- Wire up home dir option.
- Fix homedir wiring, systemd version print
- Fix client-side grpc logging middleware
- Fixes, cleanups
- README
- Cleanup/comment teamserver example gRPC, comment root types
- README
- README
- Comment teamclient example
- Simplify listener interface and Serve(), adapt code
- Tidy command generators
- Clean and readme
- README
