### PR TITLE
dev

### DIFF
--- a/client/commands/version.go
+++ b/client/commands/version.go
@@ -56,7 +56,14 @@ func versionCmd(cli *client.Client) func(cmd *cobra.Command, args []string) erro
 		fmt.Fprintf(cmd.OutOrStdout(), command.Info+"Server v%s - %s%s\n", serverSemVer, serverVer.Commit, dirty)
 
 		// Client
-		fmt.Fprintf(cmd.OutOrStdout(), command.Info+"Client %s\n", version.Full())
+		cdirty := ""
+		if version.GitDirty() {
+			cdirty = fmt.Sprintf(" - %sDirty%s", command.Bold, command.Normal)
+		}
+
+		cliVer := version.Semantic()
+		cliSemVer := fmt.Sprintf("%d.%d.%d", cliVer[0], cliVer[1], cliVer[2])
+		fmt.Fprintf(cmd.OutOrStdout(), command.Info+"Client v%s - %s%s\n", cliSemVer, version.GitCommit(), cdirty)
 
 		return nil
 	}

--- a/client/directories.go
+++ b/client/directories.go
@@ -38,6 +38,8 @@ func (tc *Client) HomeDir() string {
 		if tc.homeDir == "" {
 			user, _ := user.Current()
 			dir = filepath.Join(user.HomeDir, "."+tc.name)
+		} else {
+			dir = tc.homeDir
 		}
 	} else {
 		dir = "." + tc.name

--- a/client/options.go
+++ b/client/options.go
@@ -43,12 +43,10 @@ type opts struct {
 	logFile  string
 	inMemory bool
 	console  bool
-	local    bool
 	stdout   io.Writer
 	config   *Config
 	logger   *logrus.Logger
-	dialer   Dialer[any]
-	hooks    []func(s any) error
+	dialer   Dialer
 }
 
 func defaultOpts() *opts {
@@ -167,22 +165,9 @@ func WithLogger(logger *logrus.Logger) Options {
 //
 // This option can be used multiple times, either when using
 // team/client.New() or when using the teamclient.Connect() method.
-func WithDialer(dialer Dialer[any], hooks ...func(clientConn any) error) Options {
+func WithDialer(dialer Dialer) Options {
 	return func(opts *opts) {
 		opts.dialer = dialer
-		opts.hooks = append(opts.hooks, hooks...)
-	}
-}
-
-// WithLocalDialer sets the teamclient to connect with an in-memory dialer
-// (provided when creating the teamclient). This in effect only prevents
-// the teamclient from looking and loading/prompting remote client configs.
-//
-// Because this is automatically called by the teamserver.Serve(client)
-// function, you should probably not have any reason to use this option.
-func WithLocalDialer() Options {
-	return func(opts *opts) {
-		opts.local = true
 	}
 }
 

--- a/internal/db/sql.go
+++ b/internal/db/sql.go
@@ -83,10 +83,7 @@ func NewClient(dbConfig *Config, dbLogger *logrus.Entry) (*gorm.DB, error) {
 		return nil, fmt.Errorf("%w: '%s'", ErrUnsupportedDialect, dbConfig.Dialect)
 	}
 
-	err = dbClient.AutoMigrate(
-		&Certificate{},
-		&User{},
-	)
+	err = dbClient.AutoMigrate(Schema())
 	if err != nil {
 		dbLogger.Error(err)
 	}
@@ -109,6 +106,15 @@ func NewClient(dbConfig *Config, dbLogger *logrus.Entry) (*gorm.DB, error) {
 	return dbClient.Session(&gorm.Session{
 		FullSaveAssociations: true,
 	}), nil
+}
+
+// Schema returns all objects which should be registered
+// to the teamserver database backend.
+func Schema() []any {
+	return []any{
+		&Certificate{},
+		&User{},
+	}
 }
 
 func postgresClient(dsn string, log logger.Interface) (*gorm.DB, error) {

--- a/server/core.go
+++ b/server/core.go
@@ -22,7 +22,6 @@ import (
 	"os/user"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"sync"
 
 	"github.com/reeflective/team"
@@ -155,7 +154,7 @@ func (ts *Server) Name() string {
 // of the application using this teamserver.
 // See the server.Listener and client.Dialer types documentation for more.
 func (ts *Server) Self(opts ...client.Options) *client.Client {
-	opts = append(opts, client.WithLocalDialer())
+	// opts = append(opts, client.WithLocalDialer())
 
 	teamclient, _ := client.New(ts.Name(), ts, opts...)
 
@@ -164,7 +163,6 @@ func (ts *Server) Self(opts ...client.Options) *client.Client {
 
 // Version returns the teamserver binary version information.
 func (ts *Server) Version() (team.Version, error) {
-	dirty := version.GitDirty != ""
 	semVer := version.Semantic()
 	compiled, _ := version.Compiled()
 
@@ -180,8 +178,8 @@ func (ts *Server) Version() (team.Version, error) {
 		Major:      major,
 		Minor:      minor,
 		Patch:      patch,
-		Commit:     strings.TrimSuffix(version.GitCommit, "\n"),
-		Dirty:      dirty,
+		Commit:     version.GitCommit(),
+		Dirty:      version.GitDirty(),
 		CompiledAt: compiled.Unix(),
 		OS:         runtime.GOOS,
 		Arch:       runtime.GOARCH,

--- a/server/db.go
+++ b/server/db.go
@@ -169,6 +169,7 @@ func (ts *Server) initDatabase() (err error) {
 		dbLogger := ts.NamedLogger("database", "database")
 
 		if ts.db != nil {
+			err = ts.db.AutoMigrate(db.Schema()...)
 			return
 		}
 
@@ -183,7 +184,7 @@ func (ts *Server) initDatabase() (err error) {
 		}
 	})
 
-	return nil
+	return err
 }
 
 func (ts *Server) dbSession() *gorm.DB {

--- a/server/directories.go
+++ b/server/directories.go
@@ -41,6 +41,8 @@ func (ts *Server) HomeDir() string {
 		if ts.homeDir == "" {
 			user, _ := user.Current()
 			dir = filepath.Join(user.HomeDir, "."+ts.name)
+		} else {
+			dir = ts.homeDir
 		}
 	} else {
 		dir = "." + ts.name

--- a/server/log.go
+++ b/server/log.go
@@ -76,27 +76,18 @@ func (ts *Server) AuditLogger() (*logrus.Logger, error) {
 
 // Initialize loggers in files/stdout according to options.
 func (ts *Server) initLogging() (err error) {
-	// By default, the stdout logger is never nil.
-	// We might overwrite it below if using our defaults.
-	// ts.stdoutLogger = log.NewStdio(logrus.WarnLevel)
+	// If user supplied a logger, use it in place of the
+	// file-based logger, since the file logger is optional.
+	if ts.opts.logger != nil {
+		ts.fileLog = ts.opts.logger
+		return nil
+	}
 
 	logFile := filepath.Join(ts.LogsDir(), log.FileName(ts.Name(), true))
 
 	// If the teamserver should log to a given file.
 	if ts.opts.logFile != "" {
 		logFile = ts.opts.logFile
-	}
-
-	// Ensure all teamserver-specific directories are writable.
-	// if err := ts.checkWritableFiles(); err != nil {
-	// 	return fmt.Errorf("%w: %w", ErrDirectory, err)
-	// }
-
-	// If user supplied a logger, use it in place of the
-	// file-based logger, since the file logger is optional.
-	if ts.opts.logger != nil {
-		ts.fileLog = ts.opts.logger
-		return nil
 	}
 
 	level := logrus.Level(ts.opts.config.Log.Level)

--- a/server/server.go
+++ b/server/server.go
@@ -90,7 +90,12 @@ func (ts *Server) Serve(cli *client.Client, opts ...Options) error {
 		return err
 	}
 
-	return cli.Connect(client.WithLocalDialer())
+	// Use a fake config with a non-empty name.
+	cliOpts := []client.Options{
+		client.WithConfig(&client.Config{User: "server"}),
+	}
+
+	return cli.Connect(cliOpts...)
 }
 
 // ServeDaemon is a blocking call which starts the teamserver as daemon process, using

--- a/transports/grpc/client/client.go
+++ b/transports/grpc/client/client.go
@@ -117,7 +117,7 @@ func (h *Teamclient) Init(cli *client.Client) error {
 // It uses the teamclient remote server configuration as a target of a dial call.
 // If the connection is successful, the teamclient registers a proto.Teamclient
 // RPC around its client connection, to provide the core teamclient functionality.
-func (h *Teamclient) Dial() (rpcClient any, err error) {
+func (h *Teamclient) Dial() (err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 
@@ -125,12 +125,12 @@ func (h *Teamclient) Dial() (rpcClient any, err error) {
 
 	h.conn, err = grpc.DialContext(ctx, host, h.options...)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	h.rpc = proto.NewTeamClient(h.conn)
 
-	return h.conn, nil
+	return nil
 }
 
 // Close implements team/client.Dialer.Close(), and closes the gRPC client connection.


### PR DESCRIPTION
- Refactor most of the code into an internal directory
- Adapt server code with internal one
- Refactor client code with internal one.
- Refactor examples and adapt commands
- Refactor cobra command entrypoints and self-server
- Refactor examples
- Refactor examples
- Refactors
- Change the directories used by the teamserver apps
- Further tidy and fixes
- Refactor and cleanup log code
- Cleanup log code
- Fix logs
- Try to fix a weird connection issue
- Fix TLS keylogger
- Refactor logs, renamings, etc.
- Go mod tidy of commits to follow: - Rewrite the library with pluggable transports, clients &| server - Try to cleanup the code a bit, and fix things.
- Server refactoring with grpc backend out of there.
- Add server/transports/ directory with pluggable transports.
- Refactor log package and use file perm checks before starting servers/client/ Add a core package, which contains root-root version/users calls, and might also contain listener jobs management....
- Adapt command code with changes
- Same refactorings/cleanups client-side
- Add client/server options
- Fix logs in server
- Remove redundant config loadings
- Fixes in server
- Remove all calls to panic and replace with errors + multiple cleanups and fixes
- Database logger back
- Cleanup log calls
- Change errors formatting directives
- Cleanups
- Fix to server init to early
- Fix in-memory grpc
- Refactor code
- Cleanup commands
- Big refactoring and refining of APIs:
- First refactoring and harmonization of errors everywhere
- Change config file names/extensions.
- Move all grpc code from core
- Use commands stdout when possible
- Further cleanup/changes to log and fixes to certs
- Enhance/fix command tree
- Harmonize client logging code
- Harmonize server log code + fixes to client log
- Ensure client/server options are applied correctly
- Add job management, refactor serve start functions
- Add job control, harmonize listener serving API/internals
- Start adding job control to commands, display status + enhancements
- Harmonize logging for client: - Synchronize with io when used in commands. - Log all errors before being returned by public API. - Cleanup
- Fixes to client logging
- Harmonize server logging and sync with command io
- Refactor internal log stdio
- Split stdout/stderr logging
- Add golangci.yml file + update go.mod
- Update README
- Add github workflows
- Update go build actions
- Lint client code
- Change branch name in actions
- Fix generate
- Update workflows try to fix them
- Fixes
- Fixes to workflows
- Fix formattings
- Still
- Lint server
- Second lint pass on the server
- Fixes
- Fixes/finish client disconnect
- Move constants internally
- Ensure database is ignited where needed, even in-memory
- Ensure most of in-memory run mode code logic (certs remain)
- Finish in-memory code
- Start refactoring everything fs-related with memfs/osfs
- The client now works fully in-memory
- Add in-memory filesystem interface.
- Adapt filesystem code in client/server
- Cleanup previous commits
- Fixes
- Fix user last-seen display
- Fix users display last-seen
- Listeners completion + fixes
- Use stderr where possible, fix newlines
- Fix most logging stuff
- Several stuff: - Add most status command output - Fix listeners status - Refactors
- Harmonize listener instantiation & interface calls
- Fixes in cert code, cleanups
- Fixed duplicate logs, cleanups
- Tidy options API, fixes to audit log
- Fix status strings
- Cleanup/refactor/expose grpc transport code
- Fix logging level flag
- Use go_sqlite default without tags, rename example dirs
- Fix itoa stuff
- Fix github actions
- Fix itoa
- Fix default db build tags
- Fix itoa again
- Write comments for client package
- Add headers to all internal files + comments doc for FS
- Cleanup and comment certs package
- Cleanup db package
- Cleanup/fix/comment log package
- Comment version/tls packages
- Cleanup/command client command tree
- Fix comments in client/internal
- Comment all server package
- Add headers
- Comment/cleanup options API
- Cleanup and tighten server API
- Comment and cleanup gRPC client package
- Comment all grpc transport client/server code
- Regenerate gRPC stubs
- Cleanup comments in client/server command trees
- Wire up home dir option.
- Fix homedir wiring, systemd version print
- Fix client-side grpc logging middleware
- Fixes, cleanups
- README
- Cleanup/comment teamserver example gRPC, comment root types
- README
- README
- Comment teamclient example
- Simplify listener interface and Serve(), adapt code
- Tidy command generators
- Clean and readme
- README
- Add a completer for single-app configs.
- Uncomment panic recovery code in daemon
- Tidy and fix client package
- Tidy/factor/fix db code.
- Get rid of embedded version info
- Fixes to self-serve, log init and core code
